### PR TITLE
Add Sound BlasterX G6 Audio plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,6 @@ against
 | [Omashot](<https://github.com/brianblakely/omasnap.git>) | Brian Blakely | Screenshot and screen-recording overlay for Omarchy |
 | [Omastonk](<https://github.com/brianblakely/omastonk.git>) | Brian Blakely | Omarchy bar widget for a selected market symbol |
 | [Peek](<https://github.com/brianblakely/peek.git>) | Brian Blakely | Fades floating Hyprland windows to minimal opacity so you can see and interact with the content underneath |
+| [Sound BlasterX G6 Audio](<https://github.com/VillainRU/omarchy-soundblaster-g6.git>) | VillainRU | Show the real Sound BlasterX G6 speakers or headphones output mode in the Omarchy audio widget. |
 | [World Time](<https://github.com/mwikala/omarchy-world-time.git>) | Mwikala Kangwa | Compare a selected time across time zones. |
 <!-- END GENERATED PLUGIN CATALOG -->

--- a/plugins.txt
+++ b/plugins.txt
@@ -13,3 +13,4 @@ https://github.com/nightdevil00/bt.codecs.git
 https://github.com/yuters/omarchy-flight-radar.git
 https://github.com/brianblakely/omarchy-codex-notifications.git
 https://github.com/keithnyc/omanetwatch.git
+https://github.com/VillainRU/omarchy-soundblaster-g6.git


### PR DESCRIPTION
## What changed

- Register `https://github.com/VillainRU/omarchy-soundblaster-g6.git` in the Okomart catalog.
- Regenerate the marker-owned plugin table in `README.md`.

## Why

Sound BlasterX G6 exposes its speakers and headphones as the same PipeWire sink, so Omarchy's stock Audio widget cannot select the correct icon from the sink name alone. This plugin keeps the built-in Audio panel and reads the output mode persisted by `soundblaster-x-g6-cli`.

## User impact

This plugin is only for Creative Sound BlasterX G6 owners. It requires `soundblaster-x-g6-gui`, which provides `soundblaster-x-g6-cli`, plus the upstream USB HID/udev setup. The README documents a user-owned `SUPER+SHIFT+H` binding command; installation does not mutate Hyprland configuration automatically.

The widget reads `~/.soundblaster-x-g6/g6.json`, starts no background service, performs no polling, makes no network requests, and writes no files. The physical G6 output button does not update the CLI state file, so synchronization is guaranteed for CLI-driven switching.

## Validation

- `omarchy plugin validate .`
- `qmllint -I /usr/share/omarchy/shell Panel.qml`
- `jq empty manifest.json`
- Shell syntax check for the documented binding installer
- Runtime-tested in both `Speakers` and `Headphones` modes with a real Sound BlasterX G6
- Verified the matching speaker/headphones icons visually
- Verified no fresh QML warnings or errors after both transitions
