### PR TITLE
Add Sound Blaster plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,6 @@ against
 | [Omashot](<https://github.com/brianblakely/omasnap.git>) | Brian Blakely | Screenshot and screen-recording overlay for Omarchy |
 | [Omastonk](<https://github.com/brianblakely/omastonk.git>) | Brian Blakely | Omarchy bar widget for a selected market symbol |
 | [Peek](<https://github.com/brianblakely/peek.git>) | Brian Blakely | Fades floating Hyprland windows to minimal opacity so you can see and interact with the content underneath |
+| [Sound Blaster](<https://github.com/VillainRU/omarchy-soundblaster.git>) | VillainRU | Show device-aware output icons for supported Creative Sound Blaster hardware in the Omarchy audio widget. |
 | [World Time](<https://github.com/mwikala/omarchy-world-time.git>) | Mwikala Kangwa | Compare a selected time across time zones. |
 <!-- END GENERATED PLUGIN CATALOG -->

--- a/plugins.txt
+++ b/plugins.txt
@@ -13,3 +13,4 @@ https://github.com/nightdevil00/bt.codecs.git
 https://github.com/yuters/omarchy-flight-radar.git
 https://github.com/brianblakely/omarchy-codex-notifications.git
 https://github.com/keithnyc/omanetwatch.git
+https://github.com/VillainRU/omarchy-soundblaster.git


### PR DESCRIPTION
## What changed

- Register `https://github.com/VillainRU/omarchy-soundblaster.git` in the Okomart catalog.
- Regenerate the marker-owned plugin table in `README.md`.

## Why

Sound Blaster devices can expose multiple physical outputs through the same PipeWire sink, so Omarchy's stock Audio widget cannot always select the correct speaker or headphones icon from the sink name alone. This plugin keeps the built-in Audio panel and adds model-specific output detection.

This supersedes the closed G6-specific draft #3. The project now has a general Sound Blaster identity and a documented contribution path for adding and hardware-testing more device adapters.

## User impact

The Creative Sound BlasterX G6 is currently the only implemented and hardware-tested device. G6 support requires `soundblaster-x-g6-gui`, which provides `soundblaster-x-g6-cli`, plus its upstream USB HID/udev setup. Devices not listed in the repository's support table are not claimed as supported.

The README documents an optional user-owned `SUPER+SHIFT+H` binding for G6 output switching. Plugin installation does not mutate Hyprland configuration automatically.

The current G6 adapter watches `~/.soundblaster-x-g6/g6.json`, starts no background service, performs no polling, makes no network requests, and writes no files. The physical G6 output button does not update the CLI state file, so synchronization is guaranteed for CLI-driven switching.

## Validation

- `omarchy plugin validate .` in the plugin repository
- `jq empty manifest.json`
- Qt 6 `qmllint` completed successfully
- Okomart catalog regenerated with `node scripts/generate-plugin-catalog.mjs`
- `omarchy plugin validate .` in the Okomart repository
- `git diff --check`
- Runtime-tested in both `Speakers` and `Headphones` modes with a physical Sound BlasterX G6
