### PR TITLE
Add Hive Status plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ against
 | [Bluetooth codec](<https://github.com/nightdevil00/bt.codecs.git>) | mihai | Shift Bluetooth audio fidelity: pick the A2DP codec or headset profile for each connected Bluetooth audio device. |
 | [Codex Notifications](<https://github.com/brianblakely/omarchy-codex-notifications.git>) | Brian Blakely | Clickable lifecycle notifications that return to the originating Codex context. |
 | [Flight Radar](<https://github.com/yuters/omarchy-flight-radar.git>) | yuters | Live aircraft overhead with short-horizon flyby forecasts, an overhead badge, and notifications. Works without an account. |
+| [Hive Status](<https://github.com/ivankuznetsov/hive-omarchy.git>) | Ivan Kuznetsov | Monitor local and remote Hive daemons and their running tasks from the Omarchy bar. |
 | [Omacal](<https://github.com/brianblakely/omacal.git>) | Brian Blakely | Omarchy-native day/time label with a mini calendar popup |
 | [Omadoro](<https://github.com/brianblakely/omadoro.git>) | Brian Blakely | A Pomodoro timer for the Omarchy bar. |
 | [OmaHUD](<https://github.com/brianblakely/omahud.git>) | Brian Blakely | Flashes a discreet Hyprland workspace indicator when you switch workspaces. It's designed for people who hide their Omarchy bar most of the time, and would like help navigating their workspaces. |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ against
 | [Bluetooth codec](<https://github.com/nightdevil00/bt.codecs.git>) | mihai | Shift Bluetooth audio fidelity: pick the A2DP codec or headset profile for each connected Bluetooth audio device. |
 | [Codex Notifications](<https://github.com/brianblakely/omarchy-codex-notifications.git>) | Brian Blakely | Clickable lifecycle notifications that return to the originating Codex context. |
 | [Flight Radar](<https://github.com/yuters/omarchy-flight-radar.git>) | yuters | Live aircraft overhead with short-horizon flyby forecasts, an overhead badge, and notifications. Works without an account. |
-| [Hive Status](<https://github.com/ivankuznetsov/hive-omarchy.git>) | Ivan Kuznetsov | Monitor local and remote Hive daemons and their running tasks from the Omarchy bar. |
+| [Hive Status](<https://github.com/ivankuznetsov/hive-omarchy.git>) | Ivan Kuznetsov | Monitor Hive instances and active tasks from the Omarchy bar. |
 | [Omacal](<https://github.com/brianblakely/omacal.git>) | Brian Blakely | Omarchy-native day/time label with a mini calendar popup |
 | [Omadoro](<https://github.com/brianblakely/omadoro.git>) | Brian Blakely | A Pomodoro timer for the Omarchy bar. |
 | [OmaHUD](<https://github.com/brianblakely/omahud.git>) | Brian Blakely | Flashes a discreet Hyprland workspace indicator when you switch workspaces. It's designed for people who hide their Omarchy bar most of the time, and would like help navigating their workspaces. |

--- a/plugins.txt
+++ b/plugins.txt
@@ -13,3 +13,4 @@ https://github.com/nightdevil00/bt.codecs.git
 https://github.com/yuters/omarchy-flight-radar.git
 https://github.com/brianblakely/omarchy-codex-notifications.git
 https://github.com/keithnyc/omanetwatch.git
+https://github.com/ivankuznetsov/hive-omarchy.git

--- a/tests/catalog-workflow.test.js
+++ b/tests/catalog-workflow.test.js
@@ -30,7 +30,8 @@ const expectedUrls = [
   "https://github.com/nightdevil00/bt.codecs.git",
   "https://github.com/yuters/omarchy-flight-radar.git",
   "https://github.com/brianblakely/omarchy-codex-notifications.git",
-  "https://github.com/keithnyc/omanetwatch.git"
+  "https://github.com/keithnyc/omanetwatch.git",
+  "https://github.com/ivankuznetsov/hive-omarchy.git"
 ]
 let passed = 0
 
@@ -40,7 +41,7 @@ function test(name, callback) {
   process.stdout.write(`ok ${passed} - ${name}\n`)
 }
 
-test("plugins.txt contains the fifteen locally curated standalone URLs in deterministic order", () => {
+test("plugins.txt contains the sixteen locally curated standalone URLs in deterministic order", () => {
   assert.equal(registry.endsWith("\n"), true)
   assert.deepEqual(registry.trimEnd().split("\n"), expectedUrls)
 })


### PR DESCRIPTION
Adds Hive Status to the locally curated Okomart catalog.

Plugin repository: https://github.com/ivankuznetsov/hive-omarchy

The repository now includes a 1280x720 preview plus detailed popup and bar screenshots discoverable by Okomart.

Validation:
- Plugin GitHub Actions validation passes
- omarchy plugin validate . passes in both repositories
- Okomart tests/all.sh passes
- Catalog README regenerated with the repository script