### PR TITLE
Add Omaloom

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -13,3 +13,4 @@ https://github.com/nightdevil00/bt.codecs.git
 https://github.com/yuters/omarchy-flight-radar.git
 https://github.com/brianblakely/omarchy-codex-notifications.git
 https://github.com/keithnyc/omanetwatch.git
+https://github.com/Cause-of-a-Kind/omaloom.git


### PR DESCRIPTION
Adds [Omaloom](https://github.com/Cause-of-a-Kind/omaloom), a local-first screen recorder and MP4 library for Omarchy Quattro. The repository includes a valid manifest, installation/removal documentation, MIT license, dependencies, and marketplace preview.