### PR TITLE
Add Argus and Cassandra

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -13,3 +13,5 @@ https://github.com/nightdevil00/bt.codecs.git
 https://github.com/yuters/omarchy-flight-radar.git
 https://github.com/brianblakely/omarchy-codex-notifications.git
 https://github.com/keithnyc/omanetwatch.git
+https://github.com/diegopluna/omarchy-argus.git
+https://github.com/diegopluna/omarchy-cassandra.git


### PR DESCRIPTION
Two sibling system-watcher widgets by Diego Peter:

**[Argus](https://github.com/diegopluna/omarchy-argus)** (v0.8.0) — resource monitor: CPU, RAM, GPU, disk, network, battery, and temperature stats in the bar, with a full panel: 2m/1h sparkline history with alert markers, alerts that name the offending process, per-process GPU usage, drive SMART health, and an alert hook for automation.

**[Cassandra](https://github.com/diegopluna/omarchy-cassandra)** (v0.1.1) — event watcher: failed systemd units, journal errors, and coredumps — a calm glyph while all is quiet, urgent counts when it isn't, with a tabbed panel and desktop alerts on new failures.

Both pass `omarchy-plugin-validate`, carry `preview.png` and screenshots, and have CI-tested parsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLbV1xcSEFZ6oc2p5b9Jci