### PR TITLE
Add Exposé to the plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ against
 | [Blink](<https://github.com/brianblakely/blink.git>) | Brian Blakely | Blink briefly flashes a border over the active Hyprland window. It runs automatically when the active window changes and can also be triggered on demand. |
 | [Bluetooth codec](<https://github.com/nightdevil00/bt.codecs.git>) | mihai | Shift Bluetooth audio fidelity: pick the A2DP codec or headset profile for each connected Bluetooth audio device. |
 | [Codex Notifications](<https://github.com/brianblakely/omarchy-codex-notifications.git>) | Brian Blakely | Clickable lifecycle notifications that return to the originating Codex context. |
-| [Exposé](<https://github.com/kristofferR/omarchy-expose.git>) | Kristoffer Risanger (@kristofferR) | macOS-style Exposé for Omarchy |
+| [Exposé](<https://github.com/kristofferR/omarchy-expose.git>) | Kristoffer Risanger (@kristofferR) | macOS-style Exposé for Omarchy: one key or a hot corner shows every open window as a live preview. Type to search, press Space to Quick Look, press Enter to launch. |
 | [Flight Radar](<https://github.com/yuters/omarchy-flight-radar.git>) | yuters | Live aircraft overhead with short-horizon flyby forecasts, an overhead badge, and notifications. Works without an account. |
 | [Omacal](<https://github.com/brianblakely/omacal.git>) | Brian Blakely | Omarchy-native day/time label with a mini calendar popup |
 | [Omadoro](<https://github.com/brianblakely/omadoro.git>) | Brian Blakely | A Pomodoro timer for the Omarchy bar. |

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ against
 | [Blink](<https://github.com/brianblakely/blink.git>) | Brian Blakely | Blink briefly flashes a border over the active Hyprland window. It runs automatically when the active window changes and can also be triggered on demand. |
 | [Bluetooth codec](<https://github.com/nightdevil00/bt.codecs.git>) | mihai | Shift Bluetooth audio fidelity: pick the A2DP codec or headset profile for each connected Bluetooth audio device. |
 | [Codex Notifications](<https://github.com/brianblakely/omarchy-codex-notifications.git>) | Brian Blakely | Clickable lifecycle notifications that return to the originating Codex context. |
+| [Exposé](<https://github.com/kristofferR/omarchy-expose.git>) | Kristoffer Risanger (@kristofferR) | macOS-style Exposé for Omarchy |
 | [Flight Radar](<https://github.com/yuters/omarchy-flight-radar.git>) | yuters | Live aircraft overhead with short-horizon flyby forecasts, an overhead badge, and notifications. Works without an account. |
 | [Omacal](<https://github.com/brianblakely/omacal.git>) | Brian Blakely | Omarchy-native day/time label with a mini calendar popup |
 | [Omadoro](<https://github.com/brianblakely/omadoro.git>) | Brian Blakely | A Pomodoro timer for the Omarchy bar. |

--- a/plugins.txt
+++ b/plugins.txt
@@ -13,3 +13,4 @@ https://github.com/nightdevil00/bt.codecs.git
 https://github.com/yuters/omarchy-flight-radar.git
 https://github.com/brianblakely/omarchy-codex-notifications.git
 https://github.com/keithnyc/omanetwatch.git
+https://github.com/kristofferR/omarchy-expose.git

--- a/tests/catalog-workflow.test.js
+++ b/tests/catalog-workflow.test.js
@@ -30,7 +30,8 @@ const expectedUrls = [
   "https://github.com/nightdevil00/bt.codecs.git",
   "https://github.com/yuters/omarchy-flight-radar.git",
   "https://github.com/brianblakely/omarchy-codex-notifications.git",
-  "https://github.com/keithnyc/omanetwatch.git"
+  "https://github.com/keithnyc/omanetwatch.git",
+  "https://github.com/kristofferR/omarchy-expose.git"
 ]
 let passed = 0
 
@@ -40,7 +41,7 @@ function test(name, callback) {
   process.stdout.write(`ok ${passed} - ${name}\n`)
 }
 
-test("plugins.txt contains the fifteen locally curated standalone URLs in deterministic order", () => {
+test("plugins.txt contains the sixteen locally curated standalone URLs in deterministic order", () => {
   assert.equal(registry.endsWith("\n"), true)
   assert.deepEqual(registry.trimEnd().split("\n"), expectedUrls)
 })


### PR DESCRIPTION
Exposé is published as a standalone Omarchy overlay, but it is not available in Okomart’s curated catalog.

This adds the canonical repository URL, regenerates the catalog table, and updates the pinned registry test.

Validation:
- `tests/all.sh`
- `omarchy plugin validate .`