### PR TITLE
Add Omaudit Status to plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ against
 | [Omanote](<https://github.com/brianblakely/omanote.git>) | Brian Blakely | Omarchy-native secure scratch note for the bar |
 | [Omashot](<https://github.com/brianblakely/omasnap.git>) | Brian Blakely | Screenshot and screen-recording overlay for Omarchy |
 | [Omastonk](<https://github.com/brianblakely/omastonk.git>) | Brian Blakely | Omarchy bar widget for a selected market symbol |
+| [Omaudit Status](<https://github.com/godhiraj-code/omarchy-omaudit-status.git>) | Dhiraj Das | Summarizes Omaudit plugin risk and capability drift. |
 | [Peek](<https://github.com/brianblakely/peek.git>) | Brian Blakely | Fades floating Hyprland windows to minimal opacity so you can see and interact with the content underneath |
 | [World Time](<https://github.com/mwikala/omarchy-world-time.git>) | Mwikala Kangwa | Compare a selected time across time zones. |
 <!-- END GENERATED PLUGIN CATALOG -->

--- a/plugins.txt
+++ b/plugins.txt
@@ -17,3 +17,4 @@ https://github.com/kristofferR/omarchy-expose.git
 https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
+https://github.com/godhiraj-code/omarchy-omaudit-status.git


### PR DESCRIPTION
## Summary

- Add the canonical public Omaudit Status repository to `plugins.txt`.
- Regenerate the marker-owned README catalog.

## Plugin checks

- Standalone public repository with one root `manifest.json`.
- Globally namespaced plugin ID: `godhiraj.omaudit-status`.
- Root README documents installation, usage, dependencies, security boundaries, validation and removal.
- MIT license included.
- Official Omarchy plugin validation passed.
- Plugin repository CI is green.

Repository: https://github.com/godhiraj-code/omarchy-omaudit-status