### PR TITLE
Add Omakeyd to the plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ against
 | [Omacal](<https://github.com/brianblakely/omacal.git>) | Brian Blakely | Omarchy-native day/time label with a mini calendar popup |
 | [Omadoro](<https://github.com/brianblakely/omadoro.git>) | Brian Blakely | A Pomodoro timer for the Omarchy bar. |
 | [OmaHUD](<https://github.com/brianblakely/omahud.git>) | Brian Blakely | Flashes a discreet Hyprland workspace indicator when you switch workspaces. It's designed for people who hide their Omarchy bar most of the time, and would like help navigating their workspaces. |
+| [Omakeyd](<https://github.com/olivoil/omakeyd.git>) | Olivier Melcher | Search, create, and switch effective keyboard layouts on one explicit keyboard at a time. |
 | [OmaLED](<https://github.com/brianblakely/omaled.git>) | Brian Blakely | Dim the Omarchy bar when not in use |
 | [Omaloom](<https://github.com/Cause-of-a-Kind/omaloom.git>) | Cause of a Kind | Local-first screen recording controls for Omarchy Quattro. |
 | [OmaNetWatch](<https://github.com/keithnyc/omanetwatch.git>) | Keith | Monitor HTTP and TCP endpoints from the Omarchy bar |

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/olivoil/omakeyd.git


### PR DESCRIPTION
## Summary

- add the canonical public Omakeyd repository to plugins.txt
- regenerate the README catalog entry from its root manifest

Omakeyd is an Omarchy Quattro bar widget and service for searching, creating, and switching effective XKB layouts on one explicit keyboard. It accounts for pre-XKB remaps from keyd or keyboard firmware.

## Validation

- Omakeyd: scripts/ci.sh (13 tests)
- Omakeyd: omarchy plugin validate .
- Okomart: node scripts/generate-plugin-catalog.mjs
- Okomart: omarchy plugin validate .

## Security notes

Omakeyd runs local hyprctl and xkbcli commands, reads simple mappings from /etc/keyd when present, and writes only user-owned configuration and generated XKB symbol files. It makes no network requests and does not use privileged commands.