### PR TITLE
Add SSH Dock plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/moneytosms/omarchy-ssh-dock.git


### PR DESCRIPTION
Adds https://github.com/moneytosms/omarchy-ssh-dock.git — SSH Dock, server launcher dock for the Omarchy bar.