### PR TITLE
Add Digital Wellbeing feature

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/nihalebr/omarchy-wellbeing.git


### PR DESCRIPTION
Digital Wellbeing tracks how long each app holds focus and breaks the day down from a bar popup. A headless service samples the focused window and writes one JSON file per day. The bar hourglass opens the popup: today's total with an optional daily goal, a seven-day strip, an hourly timeline, and a most-used list.

This adds the repo URL to `plugins.txt` and nothing else.

Repository: https://github.com/nihalebr/omarchy-wellbeing

### Plugin checks
- Standalone public repo, one root `manifest.json`
- Plugin ID `nihalebr.wellbeing`, globally namespaced
- Kinds: `service`, `bar-widget`
- README covers install via `omarchy plugin add`, settings, the keybinding, data and privacy, and removal
- MIT licensed
- `omarchy plugin validate .` passes
- Tagged `v0.1.1`