### PR TITLE
Add EasyEffects Presets plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ against
 | [Blink](<https://github.com/brianblakely/blink.git>) | Brian Blakely | Blink briefly flashes a border over the active Hyprland window. It runs automatically when the active window changes and can also be triggered on demand. |
 | [Bluetooth codec](<https://github.com/nightdevil00/bt.codecs.git>) | mihai | Shift Bluetooth audio fidelity: pick the A2DP codec or headset profile for each connected Bluetooth audio device. |
 | [Codex Notifications](<https://github.com/brianblakely/omarchy-codex-notifications.git>) | Brian Blakely | Clickable lifecycle notifications that return to the originating Codex context. |
+| [EasyEffects Presets](<https://github.com/nerdyworm/omarchy-easyeffects-presets.git>) | Benjamin Rhodes | Switch EasyEffects output presets from the Omarchy bar |
 | [Exposé](<https://github.com/kristofferR/omarchy-expose.git>) | Kristoffer Risanger (@kristofferR) | macOS-style Exposé for Omarchy: one key or a hot corner shows every open window as a live preview. Type to search, press Space to Quick Look, press Enter to launch. |
 | [Flight Radar](<https://github.com/yuters/omarchy-flight-radar.git>) | yuters | Live aircraft overhead with short-horizon flyby forecasts, an overhead badge, and notifications. Works without an account. |
 | [Hive Status](<https://github.com/ivankuznetsov/hive-omarchy.git>) | Ivan Kuznetsov | Monitor Hive instances and active tasks from the Omarchy bar. |

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/nerdyworm/omarchy-easyeffects-presets.git


### PR DESCRIPTION
## Summary

- Add EasyEffects Presets to the Okomart catalog.
- The plugin switches EasyEffects output presets from the Omarchy bar.
- The plugin is published as a standalone public repository.

Plugin repository: https://github.com/nerdyworm/omarchy-easyeffects-presets

## Checks

- Omarchy plugin validation passed for Okomart.
- Omarchy plugin validation passed for the standalone plugin.
- The catalog generator completed successfully.
- The full Okomart test suite passed.
- A clean interactive install from the public Git URL passed without a shell restart.
- The preset panel, preset selection, and preset cycling were tested in the current Omarchy shell.
