### PR TITLE
Add omarchy-buds (Galaxy Buds bar plugin)

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/hmarquez-solutions/omarchy-buds.git


### PR DESCRIPTION
Adds [omarchy-buds](https://github.com/hmarquez-solutions/omarchy-buds) to the list.

Samsung Galaxy Buds in the Omarchy bar: per-bud and case battery, noise controls, ambient volume, voice detect, touch lock, equalizer and find-my-buds. A single-file Python daemon speaks Samsung's SPP protocol over BlueZ and publishes a status file the Quickshell panel watches. MIT licensed, with install/removal documented. Tested against a Galaxy Buds4 Pro.