### PR TITLE
Add SoliDB

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/solisoft/omarchy-soli-db.git


### PR DESCRIPTION
Adds [SoliDB](https://github.com/solisoft/omarchy-soli-db) to the catalog.

An Omarchy bar widget for [SoliDB](https://github.com/solisoft/solidb): live server stats — databases, collections, documents, storage, memory and traffic — with databases expanding onto their collections and sizes.

It also ships a full-screen SDBQL console: multi-line editor with syntax highlighting drawn from the server's own lexer, results as a virtualized table or JSON, cursor pagination, query history, and a document viewer that previews blob attachments inline when they are images.

Multiple servers are supported, each with either an API key or username/password; credentials live in `~/.config/omarchy/soli-db/servers.json` at `0600` rather than in `shell.json`. MIT licensed.

![preview](https://raw.githubusercontent.com/solisoft/omarchy-soli-db/main/preview.png)