### PR TITLE
Add Nebula VPN to the plugin catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ against
 | [Flight Radar](<https://github.com/yuters/omarchy-flight-radar.git>) | yuters | Live aircraft overhead with short-horizon flyby forecasts, an overhead badge, and notifications. Works without an account. |
 | [Hive Status](<https://github.com/ivankuznetsov/hive-omarchy.git>) | Ivan Kuznetsov | Monitor Hive instances and active tasks from the Omarchy bar. |
 | [Keysmith](<https://github.com/Ahmed-Sinkeat/keysmith.git>) | Ahmed-Sinkeat | Add, change, and remove Omarchy shortcuts without editing config files |
+| [Nebula VPN](<https://github.com/iryzhkov/omarchy-nebula.git>) | iryzhkov | Nebula mesh VPN status and on/off toggle in the Omarchy bar, with per-node reachability. |
 | [Omacal](<https://github.com/brianblakely/omacal.git>) | Brian Blakely | Omarchy-native day/time label with a mini calendar popup |
 | [Omadoro](<https://github.com/brianblakely/omadoro.git>) | Brian Blakely | A Pomodoro timer for the Omarchy bar. |
 | [OmaHUD](<https://github.com/brianblakely/omahud.git>) | Brian Blakely | Flashes a discreet Hyprland workspace indicator when you switch workspaces. It's designed for people who hide their Omarchy bar most of the time, and would like help navigating their workspaces. |

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/iryzhkov/omarchy-nebula.git


### PR DESCRIPTION
Adds [Nebula VPN](https://github.com/iryzhkov/omarchy-nebula) to `plugins.txt`, with the README table regenerated by `scripts/generate-plugin-catalog.mjs`.

## What it is

A bar widget for [Nebula](https://github.com/slackhq/nebula) mesh VPNs: tunnel state in the bar, a panel with an on/off switch, and a per-node reachability list with round-trip times.

Nebula has no status CLI a client can query, so the mesh list is user configuration in `shell.json` rather than discovery, probed with a parallel ping sweep. The sweep runs only while the panel is open. The README is explicit that a dot means "this peer answers over the tunnel" and does not distinguish a direct tunnel from a relayed one.

Toggling the unit needs root. The widget tries plain `systemctl` first and falls back to `pkexec`, so it works out of the box with a password prompt; the README documents an optional polkit rule, scoped to one unit and three verbs, for a promptless toggle. The plugin does not install that rule and has no setup script.

## Checklist

- One plugin manifest at the repository root; self-contained and valid standalone.
- Canonical public HTTPS `.git` URL, unique in the list, one nonblank line.
- `omarchy plugin validate .` passes in the plugin repository.
- `node scripts/generate-plugin-catalog.mjs` succeeds; the marker-owned table is current.
- No symlinks, install hooks, post-install scripts, or privileged setup.
- `schemaVersion` is the JSON number `1`; `id`, `name`, `version`, `kinds`, `entryPoints` present.
- Id `iryzhkov.nebula` is namespaced, does not start with `omarchy.`, contains no `/` or `..`.
- `kinds` is `bar-widget` only.
- Settings use `defaults` and `schema`; the node list is an inline shell setting.
- The popup-owning root exposes `opened`, `open()` and `close()`.
- Commands run, file access, network access, background behavior and required outside configuration are all documented in the README.
- No global keybindings registered; IPC endpoints documented.
- Exercised against the current Omarchy shell on Arch (aarch64, Asahi), including both toggle paths and the empty-configuration state.