### PR TITLE
Add hooji.expose — four-finger Mission Control

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/hoojiNT/omarchy-expose.git


### PR DESCRIPTION
Adds [hoojiNT/omarchy-expose](https://github.com/hoojiNT/omarchy-expose) to the catalog.

**Exposé** (`hooji.expose`) is an Omarchy 4 overlay: four fingers up lays every window of the current workspace out in a live screencopy grid; four fingers down puts it back. The overview follows the fingers — it is not an animation that plays after the gesture ends.

This is a different plugin from the already-listed [kristofferR/omarchy-expose](https://github.com/kristofferR/omarchy-expose) (hot corner / keyboard, `expose.window-overview`). Both can coexist; they use different ids.

Install:

```bash
omarchy plugin add https://github.com/hoojiNT/omarchy-expose.git
omarchy plugin enable hooji.expose
```

MIT. Preview is `preview.png` in the repo root.