### PR TITLE
Add omarchy-tidbyt

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/mfbergmann/omarchy-tidbyt.git


### PR DESCRIPTION
Adds [omarchy-tidbyt](https://github.com/mfbergmann/omarchy-tidbyt) to `plugins.txt`.

Turns a [Tidbyt](https://tidbyt.com) 64x32 LED display into an Omarchy dashboard. Dashboards are small Python files; the plugin renders them and pushes them on a timer, and adds a bar widget plus menu controls for brightness, auto-dim, dashboard selection, and removing apps from the device.

- Plugin id `io.github.mfbergmann.tidbyt`, kinds `service` and `bar-widget`
- MIT licensed, root `manifest.json`, `preview.png`, install and removal instructions in the README
- Ships an authoring guide written as an agent skill, so a coding agent can be pointed at it to build a new dashboard

Needs Tidbyt hardware and the device's API credentials to show anything; it installs and validates without them.