### PR TITLE
Add Thunderbird Mail Checker plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,5 +96,6 @@ against
 | [Omastonk](<https://github.com/brianblakely/omastonk.git>) | Brian Blakely | Omarchy bar widget for a selected market symbol |
 | [Omaudit Status](<https://github.com/godhiraj-code/omarchy-omaudit-status.git>) | Dhiraj Das | Summarizes Omaudit plugin risk and capability drift. |
 | [Peek](<https://github.com/brianblakely/peek.git>) | Brian Blakely | Fades floating Hyprland windows to minimal opacity so you can see and interact with the content underneath |
+| [Thunderbird Mail Checker](<https://github.com/VillainRU/omarchy-thunderbird-mail-checker.git>) | VillainRU | Unread Thunderbird Inbox mail in the Omarchy QuickShell bar. |
 | [World Time](<https://github.com/mwikala/omarchy-world-time.git>) | Mwikala Kangwa | Compare a selected time across time zones. |
 <!-- END GENERATED PLUGIN CATALOG -->

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/VillainRU/omarchy-thunderbird-mail-checker.git


### PR DESCRIPTION
## Summary

- add Thunderbird Mail Checker to the canonical plugin registry
- regenerate the README catalog entry
- publish plugin release 0.1.21 with event-driven IPC and reduced mail scanning

The plugin shows unread Thunderbird Inbox mail in the Omarchy QuickShell bar. Mail data stays local and is exchanged with Thunderbird through a Unix socket.

## Validation

- `node scripts/generate-plugin-catalog.mjs`
- catalog generator tests: 5 passed
- catalog workflow tests: 7 passed
- Okomart model tests: 13 passed
- launcher checks passed
- `qmllint` and static QML checks passed
- `omarchy plugin validate .`
- `git diff --check`

The Quickshell runtime smoke-test could not open the graphical display/DBus from the sandbox; all checks before runtime instantiation passed.