### PR TITLE
Add omarchy-rollback

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/TadejPolajnar/omarchy-rollback.git


### PR DESCRIPTION
Adds [omarchy-rollback](https://github.com/TadejPolajnar/omarchy-rollback): snapshot, diff, and roll back your Omarchy desktop configuration.

It continuously versions the Omarchy-managed parts of `~/.config` into a private git store, attributes every change (you, the shell, an `omarchy update` migration by name, theme, font), shows `shell.json` changes as sentences, and restores one file, one change, or a whole snapshot with a preview first.

- id `io.github.tadejpolajnar.omarchy-rollback`, kinds service + bar-widget + panel, MIT
- `omarchy plugin validate .` passes on a fresh clone; no symlinks; tests and shellcheck run in CI
- release v1.0.0