### PR TITLE
Add LEDVANCE plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ against
 | [Flight Radar](<https://github.com/yuters/omarchy-flight-radar.git>) | yuters | Live aircraft overhead with short-horizon flyby forecasts, an overhead badge, and notifications. Works without an account. |
 | [Hive Status](<https://github.com/ivankuznetsov/hive-omarchy.git>) | Ivan Kuznetsov | Monitor Hive instances and active tasks from the Omarchy bar. |
 | [Keysmith](<https://github.com/Ahmed-Sinkeat/keysmith.git>) | Ahmed-Sinkeat | Add, change, and remove Omarchy shortcuts without editing config files |
+| [LEDVANCE](<https://github.com/Hank-dev/ledvance.git>) | Hanky | Local LEDVANCE SMART+ / Tuya Wi-Fi light controls for the Omarchy bar, with optional theme-accent follow |
 | [Omacal](<https://github.com/brianblakely/omacal.git>) | Brian Blakely | Omarchy-native day/time label with a mini calendar popup |
 | [Omadoro](<https://github.com/brianblakely/omadoro.git>) | Brian Blakely | A Pomodoro timer for the Omarchy bar. |
 | [OmaHUD](<https://github.com/brianblakely/omahud.git>) | Brian Blakely | Flashes a discreet Hyprland workspace indicator when you switch workspaces. It's designed for people who hide their Omarchy bar most of the time, and would like help navigating their workspaces. |

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/Hank-dev/ledvance.git


### PR DESCRIPTION
## Summary
- Adds [LEDVANCE](https://github.com/Hank-dev/ledvance.git) to `plugins.txt` and regenerates the README catalog.

Local LEDVANCE SMART+ / Tuya Wi-Fi light controls for the Omarchy bar (power, brightness, white tone, color, optional theme-accent follow). Control stays on the LAN.

Install URL: `https://github.com/Hank-dev/ledvance.git`

## Test plan
- [ ] `omarchy plugin validate` against a clone of Hank-dev/ledvance
- [ ] Catalog generator includes the LEDVANCE row
- [ ] `omarchy plugin add https://github.com/Hank-dev/ledvance.git` clones a root `manifest.json`