### PR TITLE
Add Azure VPN to the plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ against
 
 | Plugin | Author | Description |
 | --- | --- | --- |
+| [Azure VPN](<https://github.com/jellespijker/omarchy-azure-vpn.git>) | Jelle Spijker | Headless Microsoft Azure Point-to-Site VPN controller with Entra ID SSO |
 | [Blink](<https://github.com/brianblakely/blink.git>) | Brian Blakely | Blink briefly flashes a border over the active Hyprland window. It runs automatically when the active window changes and can also be triggered on demand. |
 | [Bluetooth codec](<https://github.com/nightdevil00/bt.codecs.git>) | mihai | Shift Bluetooth audio fidelity: pick the A2DP codec or headset profile for each connected Bluetooth audio device. |
 | [Codex Notifications](<https://github.com/brianblakely/omarchy-codex-notifications.git>) | Brian Blakely | Clickable lifecycle notifications that return to the originating Codex context. |

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/jellespijker/omarchy-azure-vpn.git


### PR DESCRIPTION
Submitted on behalf of the plugin author, Jelle Spijker (@jellespijker).

Adds [Azure VPN](https://github.com/jellespijker/omarchy-azure-vpn) to `plugins.txt`, with the README table regenerated by `scripts/generate-plugin-catalog.mjs`.

## What it is

A lightweight, headless Microsoft Azure Point-to-Site VPN controller with Microsoft Entra ID (Azure AD) SSO for the Omarchy Quattro bar.
It replaces bulky proprietary GUI clients by orchestrating the open-source `openp2s` and OpenVPN engine across standard process boundaries.

Features:
- Live connection state, IP/DNS, and tunnel duration displayed on the Omarchy bar.
- Interactive Entra ID browser SSO authentication flow with automated callback handling.
- XML profile importing (`.ovpn` / `.xml` Azure client profiles) directly into user configuration.
- Hardened security model: scoped sudoers rule for `/usr/local/lib/openp2s/openvpn` and `/usr/bin/resolvectl` (validated via `visudo -c`), SHA256 tarball verification, and clean systemd user service management.
- Complete teardown support via `azurevpn teardown`.

## Pre-Publish Checklist Verification

- [x] One plugin manifest at the repository root; self-contained and valid standalone.
- [x] Canonical public HTTPS `.git` URL (`https://github.com/jellespijker/omarchy-azure-vpn.git`), unique in the list, one nonblank line.
- [x] `omarchy plugin validate .` passes in the plugin repository (exits 0).
- [x] `omarchy plugin validate .` passes in the catalog repository (exits 0).
- [x] `node scripts/generate-plugin-catalog.mjs` succeeds and the marker-owned table is current.
- [x] No symlinks, install hooks, or post-install scripts inside the plugin repository.
- [x] `schemaVersion` is the JSON number `1`; `id`, `name`, `version`, `kinds`, `entryPoints` present.
- [x] Id `jellespijker.azure-vpn` is namespaced, does not start with `omarchy.`, and contains no `/` or `..`.
- [x] `kinds` is `bar-widget` only.
- [x] The popup-owning root exposes `opened`, `open()`, and `close()`.
- [x] Commands executed, file access, network access, background behavior, and setup/teardown instructions are fully documented in the repository's README.
- [x] Comprehensive legal, trademarks, and architecture notice included in README detailing upstream licensing boundaries (MIT plugin wrapper around GPL-2.0 openp2s/openvpn, zero proprietary Microsoft code).
- [x] Exercised and tested live against Omarchy Quattro on Arch Linux.
