### PR TITLE
Add YubiKey TOTP to the plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,5 @@ against
 | [Omaudit Status](<https://github.com/godhiraj-code/omarchy-omaudit-status.git>) | Dhiraj Das | Summarizes Omaudit plugin risk and capability drift. |
 | [Peek](<https://github.com/brianblakely/peek.git>) | Brian Blakely | Fades floating Hyprland windows to minimal opacity so you can see and interact with the content underneath |
 | [World Time](<https://github.com/mwikala/omarchy-world-time.git>) | Mwikala Kangwa | Compare a selected time across time zones. |
+| [YubiKey TOTP](<https://github.com/jellespijker/omarchy-yubikey-totp.git>) | Jelle Spijker | Native YubiKey OATH / TOTP two-factor authentication manager with quick clipboard copy, touch prompts, and live countdown |
 <!-- END GENERATED PLUGIN CATALOG -->

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/jellespijker/omarchy-yubikey-totp.git


### PR DESCRIPTION
Submitted on behalf of the plugin author, Jelle Spijker (@jellespijker).

Adds YubiKey TOTP (https://github.com/jellespijker/omarchy-yubikey-totp) to `plugins.txt`, with the README table regenerated by `scripts/generate-plugin-catalog.mjs`.

## What it is

A native, hardware-backed YubiKey OATH / TOTP two-factor authentication manager for the Omarchy Quattro bar.
It reads TOTP credentials directly from physical YubiKeys via PC/SC smartcard interface (`yubikit` / `ykman`) with zero reliance on cloud or local secrets storage.

Features:
- Live 30-second epoch countdown ticker synchronized with RFC 6238 time-step boundaries and urgent color shift.
- Anti-staleness rollover protection: automatically delays and fetches the fresh token if <= 2.5s remain when copying to prevent expiring keys on paste.
- One-click clipboard copy (`wl-copy`) with instant checkmark feedback and desktop notifications.
- Hardware touch prompt detection (`touch_required`) with an animated pulsing touch banner.
- Real-time fuzzy filtering across issuers and accounts (press `/` to search).
- Star pinning for favorite credentials.
- Screen QR code scanner using `slurp` + `grim` + `zbarimg` for instant 2FA account enrollment onto the key.
- Extensive brand & crypto icon mapping engine (`Icons.js`) covering 60+ platforms across Crypto/Web3, Banking/Fintech, Cloud, Dev/DevOps, Gaming, Social, Smart Home, 3D Printing, and Linux.
- Offline demo preview mode for testing UI states when hardware is disconnected.

## Pre-Publish Checklist Verification

- [x] One plugin manifest at the repository root; self-contained and valid standalone.
- [x] Canonical public HTTPS `.git` URL (`https://github.com/jellespijker/omarchy-yubikey-totp.git`), unique in the list, one nonblank line.
- [x] `omarchy plugin validate .` passes in the plugin repository (exits 0).
- [x] `omarchy plugin validate .` passes in the catalog repository (exits 0).
- [x] `node scripts/generate-plugin-catalog.mjs` succeeds and the marker-owned table is current.
- [x] Full test suite `bash tests/all.sh` passes (87 backend tests, model, launcher, QML, catalog generator & workflow tests).
- [x] No symlinks, install hooks, or post-install scripts inside the plugin repository.
- [x] `schemaVersion` is the JSON number `1`; `id`, `name`, `version`, `kinds`, `entryPoints` present.
- [x] Id `jellespijker.yubikey-totp` is namespaced, does not start with `omarchy.`, and contains no `/` or `..`.
- [x] `kinds` is `bar-widget` only.
- [x] The popup-owning root exposes `opened`, `open()`, and `close()`.
- [x] Commands executed, file access, PC/SC smartcard access, background behavior, and setup instructions are fully documented in the repository's README.
- [x] Exercised and tested live against Omarchy Quattro on Arch Linux with physical YubiKey 5 NFC hardware.