### PR TITLE
Add media-idle-inhibit plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/pxllbt/media-idle-inhibit.git


### PR DESCRIPTION
Adds the **Media Idle Inhibit** plugin to the Okomart catalog (per the contribution instructions in the README).

- Plugin id: `io.github.pixllbeat.media-idle-inhibit`
- Kinds: `service` + `bar-widget`
- Summary: Suppresses the screensaver/session lock while MPRIS media is playing, via `omarchy-toggle-idle`
- Repo: https://github.com/pxllbt/media-idle-inhibit

PR adds `https://github.com/pxllbt/media-idle-inhibit.git` to `plugins.txt`.