### PR TITLE
Add Fleet Security to the plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ against
 | [Bluetooth codec](<https://github.com/nightdevil00/bt.codecs.git>) | mihai | Shift Bluetooth audio fidelity: pick the A2DP codec or headset profile for each connected Bluetooth audio device. |
 | [Codex Notifications](<https://github.com/brianblakely/omarchy-codex-notifications.git>) | Brian Blakely | Clickable lifecycle notifications that return to the originating Codex context. |
 | [Exposé](<https://github.com/kristofferR/omarchy-expose.git>) | Kristoffer Risanger (@kristofferR) | macOS-style Exposé for Omarchy: one key or a hot corner shows every open window as a live preview. Type to search, press Space to Quick Look, press Enter to launch. |
+| [Fleet Security](<https://github.com/jellespijker/omarchy-fleet.git>) | Jelle Spijker | Real-time FleetDM vulnerability scanner, CISA KEV alerts, and host security triage monitor |
 | [Flight Radar](<https://github.com/yuters/omarchy-flight-radar.git>) | yuters | Live aircraft overhead with short-horizon flyby forecasts, an overhead badge, and notifications. Works without an account. |
 | [Hive Status](<https://github.com/ivankuznetsov/hive-omarchy.git>) | Ivan Kuznetsov | Monitor Hive instances and active tasks from the Omarchy bar. |
 | [Keysmith](<https://github.com/Ahmed-Sinkeat/keysmith.git>) | Ahmed-Sinkeat | Add, change, and remove Omarchy shortcuts without editing config files |

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/jellespijker/omarchy-fleet.git


### PR DESCRIPTION
Submitted on behalf of the plugin author, Jelle Spijker (@jellespijker).

Adds Fleet Security (https://github.com/jellespijker/omarchy-fleet) to `plugins.txt`, with the README table regenerated by `scripts/generate-plugin-catalog.mjs`.

## What it is

A real-time FleetDM vulnerability scanner, CISA KEV alerts monitor, and host security triage manager for the Omarchy Quattro bar.
It continuously queries local FleetDM instances or fleetctl configurations to surface active zero-day threats, multi-host software package exposures, and target-specific remediation scripts across Arch, Debian/Ubuntu, Fedora, and Windows fleets.

Features:
- **CISA KEV Actively Exploited Zero-Day Tracking**: Automatically cross-references detected CVEs against CISA's official Known Exploited Vulnerabilities catalog with real-time critical badge counters and severity tiering.
- **Synthesized Multi-Host Vulnerability Triage**: Groups duplicate CVEs across fleet hosts into unified package entries with host attribution chips (`[arch-prod]`, `[dev-workstation]`) and online/offline status indicators.
- **One-Click Target-Aware Remediation**: Synthesizes host-aware remediation commands (`sudo pacman -Syu ...`, `ssh -t arch-prod "sudo apt update && sudo apt install --only-upgrade ..."`, `winget upgrade ...`) ready for 1-click clipboard copy (`wl-copy`) or 1-click floating terminal execution.
- **Interactive Terminal Triage & Host Management**: Integrated companion CLIs (`fleet-triage`, `fleet-monitor`, `fleet-setup`) for deep command-line inspection and bootstrap configuration.
- **False-Positive & Noise Snoozing**: Mute noisy packages or known distribution epoch mismatches locally into `~/.config/omarchy/fleet_ignored.json` with an expandable muted drawer in the UI.
- **Built-in Offline Synthetic Demo Mode**: Toggle full-spectrum demonstration fleet telemetry (`D` key or header switch) to safely preview and test all alert states without requiring a live Fleet server.

## Pre-Publish Checklist Verification

- [x] One plugin manifest at the repository root; self-contained and valid standalone.
- [x] Canonical public HTTPS `.git` URL (`https://github.com/jellespijker/omarchy-fleet.git`), unique in the list, one nonblank line.
- [x] `omarchy plugin validate .` passes in the plugin repository (exits 0).
- [x] `omarchy plugin validate .` passes in the catalog repository (exits 0).
- [x] `node scripts/generate-plugin-catalog.mjs` succeeds and the marker-owned table is current.
- [x] Full test suite `bash tests/all.sh` passes (87 backend tests, model, launcher, QML, catalog generator & workflow tests).
- [x] No symlinks, install hooks, or post-install scripts inside the plugin repository.
- [x] `schemaVersion` is the JSON number `1`; `id`, `name`, `version`, `kinds`, `entryPoints` present.
- [x] Id `jellespijker.fleet` is namespaced, does not start with `omarchy.`, and contains no `/` or `..`.
- [x] `kinds` is `bar-widget` only.
- [x] The popup-owning root exposes `opened`, `open()`, and `close()`.
- [x] Commands executed, file access, network access, background behavior, and setup instructions are fully documented in the repository's README.
- [x] Full Claude Opus security review conducted: remediations sanitized with `shlex.quote` and regex checks, credential masking via `getpass`, no PII/secrets or private IPs exposed, and clean initial git history.
- [x] Exercised and tested live against Omarchy Quattro on Arch Linux.