### PR TITLE
Add Ichi to the plugin catalog

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -18,3 +18,4 @@ https://github.com/Ahmed-Sinkeat/keysmith.git
 https://github.com/Cause-of-a-Kind/omaloom.git
 https://github.com/ivankuznetsov/hive-omarchy.git
 https://github.com/godhiraj-code/omarchy-omaudit-status.git
+https://github.com/aesko/omarchy-ichi.git


### PR DESCRIPTION
## Summary
- Adds [Ichi](https://github.com/aesko/omarchy-ichi) (`io.github.aesko.ichi`) to `plugins.txt`.
- Ichi insets the lone window on a workspace — a percentage of the screen or an aspect ratio, per workspace, adjustable live — while keeping it tiled. A second window gets the whole screen back.
- Service plugin, MIT, no dependencies beyond Omarchy 4.x and Hyprland ≥ 0.55. `manifest.json`, `README.md`, `LICENSE`, `preview.png` and `icon.png` are in the repo root; `omarchy plugin validate` passes and a cold `omarchy plugin add … --enable` was verified.

## Test plan
- [ ] Catalog workflow regenerates the README table with the Ichi row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfFvfr4d4kMcw3eV29u7Jm